### PR TITLE
Webhook alarms, Bug fixing and default alarm options

### DIFF
--- a/3rdparty/curl.php
+++ b/3rdparty/curl.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * This class is a handy wrapper for using curl
+ * @author original author http://php.net/manual/fr/book.curl.php#90821
+ * modified bye
+ * @author Jérémy Munsch <jeremy.munsch@gmail.com>
+ * @copyright https://creativecommons.org/publicdomain/mark/1.0/
+ */
+class Curl
+{
+        protected $_useragent = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1';
+        protected $_url;
+        protected $_followlocation;
+        protected $_timeout;
+        protected $_maxRedirects;
+        protected $_cookieFileLocation = null;
+        protected $_post;
+        protected $_postFields;
+        protected $_referer = "http://www.google.com";
+        protected $_debug = false;
+
+        protected $_session;
+        protected $_webpage;
+        protected $_includeHeader;
+        protected $_noBody;
+        protected $_status;
+        protected $_contentType;
+        protected $_infos;
+        protected $_binaryTransfer;
+        public $authentication = 0;
+        public $auth_name      = '';
+        public $auth_pass      = '';
+
+        public function useAuth($use)
+        {
+            $this->authentication = 0;
+            if ($use == true) {
+                $this->authentication = 1;
+            }
+        }
+
+        public function setName($name)
+        {
+            $this->auth_name = $name;
+        }
+
+        public function setPass($pass)
+        {
+            $this->auth_pass = $pass;
+        }
+
+        public function __construct($url, $followlocation = true, $timeOut = 30, $maxRedirecs = 4, $binaryTransfer = false, $includeHeader = false, $noBody = false)
+        {
+            $this->_url = $url;
+            $this->_followlocation = $followlocation;
+            $this->_timeout = $timeOut;
+            $this->_maxRedirects = $maxRedirecs;
+            $this->_noBody = $noBody;
+            $this->_includeHeader = $includeHeader;
+            $this->_binaryTransfer = $binaryTransfer;
+        }
+
+        public function setDebug($debug)
+        {
+            $this->_debug = $debug;
+        }
+
+        public function setReferer($referer)
+        {
+            $this->_referer = $referer;
+        }
+
+        public function setCookieFileLocation($path)
+        {
+            $this->_cookieFileLocation = $path;
+        }
+
+        public function setPost ($postFields)
+        {
+            $this->_post = true;
+            $this->_postFields = $postFields;
+        }
+
+        public function setUserAgent($userAgent)
+        {
+            $this->_useragent = $userAgent;
+        }
+
+        public function createCurl($url = null)
+        {
+            if ($url) {
+                $this->_url = $url;
+            }
+
+            $s = curl_init();
+
+            curl_setopt($s, CURLOPT_URL, $this->_url);
+            curl_setopt($s, CURLOPT_HTTPHEADER, array('Expect:'));
+            curl_setopt($s, CURLOPT_TIMEOUT, $this->_timeout);
+            curl_setopt($s, CURLOPT_MAXREDIRS, $this->_maxRedirects);
+            curl_setopt($s, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($s, CURLOPT_FOLLOWLOCATION, $this->_followlocation);
+
+            if ($this->_debug) {
+                curl_setopt($s, CURLOPT_VERBOSE, true);
+            }
+
+            if ($this->_cookieFileLocation) {
+                curl_setopt($s, CURLOPT_COOKIEJAR, $this->_cookieFileLocation);
+                curl_setopt($s, CURLOPT_COOKIEFILE, $this->_cookieFileLocation);
+            }
+
+            if ($this->authentication == 1) {
+                curl_setopt($s, CURLOPT_USERPWD, $this->auth_name.':'.$this->auth_pass);
+            }
+            if ($this->_post) {
+                curl_setopt($s, CURLOPT_POST, true);
+                curl_setopt($s, CURLOPT_POSTFIELDS, $this->_postFields);
+
+            }
+
+            if ($this->_includeHeader) {
+                curl_setopt($s, CURLOPT_HEADER, true);
+            }
+
+            if ($this->_noBody) {
+                curl_setopt($s, CURLOPT_NOBODY, true);
+            }
+            if($this->_binaryTransfer) {
+             curl_setopt($s,CURLOPT_BINARYTRANSFER,true);
+            }
+            curl_setopt($s, CURLOPT_USERAGENT, $this->_useragent);
+            curl_setopt($s, CURLOPT_REFERER, $this->_referer);
+
+            $this->_webpage = curl_exec($s);
+            $this->_status = curl_getinfo($s, CURLINFO_HTTP_CODE);
+            $this->_contentType = curl_getinfo($s, CURLINFO_CONTENT_TYPE);
+            $this->_infos = curl_getinfo($s);
+
+            curl_close($s);
+
+        }
+
+        public function getHttpStatus()
+        {
+            return $this->_status;
+        }
+
+        public function getContentType()
+        {
+            return $this->_contentType;
+        }
+
+        public function getInfos()
+        {
+            return $this->_infos;
+        }
+
+        public function getDebug()
+        {
+            return $this->_infos;
+        }
+
+        public function __tostring()
+        {
+            return $this->_webpage;
+        }
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ CREATE TABLE `oc_clndr_alarms` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `objid` int(10) unsigned NOT NULL DEFAULT '0',
   `value` varchar(255) COLLATE utf8_bin NOT NULL,
+  `optionfield` varchar(1024) COLLATE utf8_bin NOT NULL,
   `timetype` varchar(255) COLLATE utf8_bin NOT NULL,
   `senddate` datetime NOT NULL DEFAULT '1970-01-01 00:00:00',
   `type` varchar(255) COLLATE utf8_bin NOT NULL,

--- a/ajax/event/edit.php
+++ b/ajax/event/edit.php
@@ -31,7 +31,7 @@ if($errarr) {
 
 	OC_Calendar_App::isNotModified($vcalendar->VEVENT, $_POST['lastmodified']);
 	OC_Calendar_Object::updateVCalendarFromRequest($_POST, $vcalendar);
-	OC_Calendar_Object::addAlarmsDB($_POST['alarmsDuration'], $_POST['alarmsType'], $_POST['alarmsTimeType'], $vcalendar->VEVENT, $id);
+	OC_Calendar_Object::addAlarmsDB($_POST['alarmsDuration'], $_POST['alarmsOptionField'], $_POST['alarmsType'], $_POST['alarmsTimeType'], $vcalendar->VEVENT, $id);
 
 	try {
 		OC_Calendar_Object::edit($id, $vcalendar->serialize());

--- a/ajax/event/new.form.php
+++ b/ajax/event/new.form.php
@@ -74,17 +74,37 @@ $tmpl->assign('repeat_byweekno_options', $repeat_byweekno_options);
 $tmpl->assign('repeat_bymonthday_options', $repeat_bymonthday_options);
 $tmpl->assign('repeat_weekofmonth_options', $repeat_weekofmonth_options);
 
-$tmpl->assign('alarms', array(
-  array(
-	'type' => 'DISPLAY',
-	'value' => 10,
-	'timetype' => 'M'),
-  array(
-	'type' => 'EMAIL',
-	'value' => 10,
-	'timetype' => 'M'
-  )
-));
+$_alarms = array();
+$_alarmsType = explode('|', OCP\Config::getUserValue( OCP\USER::getUser(), 'calendar', 'defaultalarms' ));
+
+if (in_array('DISPLAY', $_alarmsType)) {
+	$_alarms[] =   array(
+		'type' => 'DISPLAY',
+		'value' => 10,
+		'optionfield' => '',
+		'timetype' => 'M'
+	);
+}
+
+if (in_array('EMAIL', $_alarmsType)) {
+	$_alarms[] =   array(
+		'type' => 'EMAIL',
+		'value' => 10,
+		'optionfield' => '',
+		'timetype' => 'M'
+	);
+}
+
+if (in_array('WEBHOOK', $_alarmsType)) {
+	$_alarms[] =   array(
+		'type' => 'WEBHOOK',
+		'value' => 10,
+		'optionfield' => OCP\Config::getUserValue( OCP\USER::getUser(), 'calendar', 'webhookdefaulturl' ),
+		'timetype' => 'M'
+	);
+}
+
+$tmpl->assign('alarms', $_alarms);
 
 $tmpl->assign('eventid', 'new');
 $tmpl->assign('startdate', $start->format('d-m-Y'));

--- a/ajax/event/new.php
+++ b/ajax/event/new.php
@@ -22,7 +22,7 @@ if($errarr) {
 	$vcalendar = OC_Calendar_Object::createVCalendarFromRequest($_POST);
 	try {
 		$objectId = OC_Calendar_Object::add($cal, $vcalendar->serialize());
-		OC_Calendar_Object::addAlarmsDB($_POST['alarmsDuration'], $_POST['alarmsType'], $_POST['alarmsTimeType'], $vcalendar->VEVENT, $objectId);
+		OC_Calendar_Object::addAlarmsDB($_POST['alarmsDuration'], $_POST['alarmsOptionField'], $_POST['alarmsType'], $_POST['alarmsTimeType'], $vcalendar->VEVENT, $objectId);
 	} catch(Exception $e) {
 		OCP\JSON::error(array('message'=>$e->getMessage()));
 		exit;

--- a/ajax/settings/setdefaultalarms.php
+++ b/ajax/settings/setdefaultalarms.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright (c) 2011 Bart Visscher <bartv@thisnet.nl>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+// Init owncloud
+
+
+$l = OCP\Util::getL10N('calendar');
+
+// Check if we are a user
+OCP\JSON::checkLoggedIn();
+OCP\JSON::checkAppEnabled('calendar');
+OCP\JSON::callCheck();
+
+// Get data
+if( isset( $_POST['defaultalarms'] ) ) {
+    $defaultalarms = $_POST['defaultalarms'];
+    $match = preg_match('/^(?:display){0,1}?\b\|?(?:email){0,1}?\b\|?(?:webhook){0,1}?\b$/i', $defaultalarms);
+    if ($match === 1 OR empty($defaultalarms)) {
+        OCP\Config::setUserValue( OCP\USER::getUser(), 'calendar', 'defaultalarms', strtoupper($defaultalarms) );
+        OCP\JSON::success(array('data' => array( 'message' => $l->t('Default reminders changed') )));
+    } else {
+        OCP\JSON::error(array('data' => array( 'message' => $l->t('Invalid request') )));
+    }
+}else{
+    OCP\JSON::error(array('data' => array( 'message' => $l->t('Invalid request') )));
+}

--- a/ajax/settings/setwebhookdefaulturl.php
+++ b/ajax/settings/setwebhookdefaulturl.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright (c) 2011 Bart Visscher <bartv@thisnet.nl>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+// Init owncloud
+
+
+$l = OCP\Util::getL10N('calendar');
+
+// Check if we are a user
+OCP\JSON::checkLoggedIn();
+OCP\JSON::checkAppEnabled('calendar');
+OCP\JSON::callCheck();
+
+$regex = "/^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\x{00a1}-\x{ffff}0-9]-*)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.(?:[a-z\x{00a1}-\x{ffff}0-9]-*)*[a-z\x{00a1}-\x{ffff}0-9]+)*(?:\.(?:[a-z\x{00a1}-\x{ffff}]{2,}))\.?)(?:\:\d{2,5})?(?:[\/?#]\S*)?$/iu";
+// Get data
+if( isset( $_POST['webhookdefaulturl'] ) ) {
+    $webhookdefaulturl = trim($_POST['webhookdefaulturl']);
+    $match = preg_match($regex, $webhookdefaulturl);
+    if ($match === 1 OR empty($webhookdefaulturl)) {
+        OCP\Config::setUserValue( OCP\USER::getUser(), 'calendar', 'webhookdefaulturl', $webhookdefaulturl );
+        OCP\JSON::success(array('data' => array( 'message' => $l->t('Default webhook url reminder changed') )));
+    } else {
+        OCP\JSON::error(array('data' => array( 'message' => $l->t('Url is invalid') )));
+    }
+}else{
+    OCP\JSON::error(array('data' => array( 'message' => $l->t('Invalid request') )));
+}
+

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -374,6 +374,13 @@
 				<length>255</length>
 			</field>
 
+      <field>
+        <name>optionfield</name>
+        <type>text</type>
+        <notnull>false</notnull>
+        <length>1024</length>
+      </field>
+
 			<field>
 				<name>timetype</name>
 				<type>text</type>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -118,6 +118,11 @@ $this->create('calendar_settings_timeformat', 'ajax/settings/timeformat.php')
 $this->create('calendar_settings_timezonedetection', 'ajax/settings/timezonedetection.php')
 	->actionInclude('calendar/ajax/settings/timezonedetection.php');
 
+$this->create('calendar_settings_setdefaultalarms', 'ajax/settings/setdefaultalarms.php')
+	->actionInclude('calendar/ajax/settings/setdefaultalarms.php');
+
+$this->create('calendar_settings_setwebhookdefaulturls', 'ajax/settings/setwebhookdefaulturl.php')
+	->actionInclude('calendar/ajax/settings/setwebhookdefaulturl.php');
 
 $this->create('calendar_root_calendar', 'calendar.php')
 	->actionInclude('calendar/calendar.php');

--- a/css/style.css
+++ b/css/style.css
@@ -601,3 +601,44 @@ button.ui-multiselect{
 	display: inline;
 }
 
+.alarmOptionField {
+       display: block;
+}
+
+label.alarmOptionField {
+       margin-top: -4px;
+}
+
+label.alarmOptionField > span,
+label.alarmOptionField > input {
+       display: inline-block;
+}
+
+span.alarmDefault {
+	display: block;
+}
+input.alarmDefault {
+	display: inline-block;
+	width: 14%;
+}
+.alarmDefault + label {
+	display: inline-block;
+	width: 80%;
+}
+
+.webhookUrlEvent {
+	color: whitesmoke;
+	width: 80%;
+	display: block;
+	padding: 2px;
+	text-align: center;
+}
+
+.webhookUrlEvent.webhookUrlEventSuccess {
+	background-color: #007700;
+}
+
+.webhookUrlEvent.webhookUrlEventError {
+	background-color: #C20000;
+}
+

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -305,7 +305,7 @@ Calendar={
 			});
 		},
 		addAlarm:function(){
-			newAlarm = $('#eventAlarms').children().first().clone();
+			newAlarm = $(Calendar.UI.ALARMBASETPL);
 			newAlarm.attr('id', null);
 			newAlarm.css('display', 'block');
 			newAlarm.find('.alarmDuration').val(10);
@@ -316,20 +316,19 @@ Calendar={
 				$(this).find('.alarmType').attr('name', 'alarmsType[' + i + ']');
 				$(this).find('.alarmDuration').attr('name', 'alarmsDuration[' + i + ']');
 				$(this).find('.alarmTimeType').attr('name', 'alarmsTimeType[' + i + ']');
+				$(this).find('.alarmOptionField').attr('name', 'alarmsOptionField[' + i + ']');
 				i++;
 			});
 
 		},
-		deleteAlarm:function(deleteButton){
-			if($('#eventAlarms .alarm').length == 1){
-				alarm = $(deleteButton).parent();
-				alarm.css('display', 'none');
-				alarm.find('.alarmType').attr('name', '');
-				alarm.find('.alarmDuration').attr('name', '');
-				alarm.find('.alarmTimeType').attr('name', '');
-			}
-			else{
-				$(deleteButton).parent().remove();
+		deleteAlarm:function(deleteButton) {
+			$(deleteButton).parent().remove();
+		},
+		switchAlarmType:function() {
+			if($(this).val() === 'WEBHOOK') {
+				$(this).parent().find('.alarmOptionField').show();
+			} else {
+				$(this).parent().find('.alarmOptionField').hide();
 			}
 		},
 		showadvancedoptions:function(){

--- a/js/on-event.js
+++ b/js/on-event.js
@@ -92,3 +92,7 @@ $('.deleteAlarm').live('click', function(e){
 	Calendar.UI.deleteAlarm(this);
 	e.preventDefault();
 });
+$('.alarmType').live('change', function(e){
+	Calendar.UI.switchAlarmType.apply(this);
+	e.preventDefault();
+});

--- a/js/settings.js
+++ b/js/settings.js
@@ -45,6 +45,25 @@ $(document).ready(function(){
 		});
 	});
 	calendarcachecheck();
+	$('input.alarmDefault').on('change', function() {
+		var checked = '';
+		$('input.alarmDefault').each(function() {
+			if ($(this).prop('checked')) {
+				checked += (checked.length?'|':'')+$(this).prop('name');
+			};
+		});
+		$.post( OC.filePath('calendar', 'ajax/settings', 'setdefaultalarms.php'), 'defaultalarms='+checked);
+	});
+	$('#alarmDefaultWebhookURL').on('change', function() {
+		$.post( OC.filePath('calendar', 'ajax/settings', 'setwebhookdefaulturl.php'), 'webhookdefaulturl='+encodeURIComponent($(this).val()),
+			function(jsondata, status) {
+				var label = $('<b class="webhookUrlEvent"></b>');
+				label.addClass(jsondata.status === "success"?'webhookUrlEventSuccess':'webhookUrlEventError');
+				label.text(jsondata.data.message);
+				$("#alarmDefaultWebhookURL").before(label)
+				label.fadeOut(10000, 'easeInExpo', function() { $(this).remove() });
+		});
+	});
 
 });
 function calendarcachecheck(){

--- a/lib/alarm.php
+++ b/lib/alarm.php
@@ -1,5 +1,7 @@
 <?php
 
+OC::$CLASSPATH['Curl'] = 'calendar/3rdparty/curl.php';
+
 /**
  * This file is licensed under the Affero General Public License version 3 or
  * later.
@@ -7,80 +9,195 @@
  */
 /*
  * This class manages alarms for calendars
- */
-class OC_Calendar_Alarm extends \OC\BackgroundJob\TimedJob{
+*/
+class OC_Calendar_Alarm extends \OC\BackgroundJob\TimedJob
+{
+    public function __construct()
+    {
+        $this->interval = 60;
+    }
 
-	public function __construct() {
-		$this->interval = 60;
-	}
+    public function run($argument)
+    {
+        // OCP\Util::writeLog('calendar background job', 'Started', OCP\Util::DEBUG);
+        try {
+            self::dispatch();
+        } catch (\Exception $e) {
+            OC_Log::write('calendar background job', 'Exception: '.$e->getMessage(), OCP\Util::DEBUG);
 
-	public function run($argument) {
-	        OCP\Util::writeLog('calendar background job', 'Started', OCP\Util::DEBUG);
-		self::sendEmailAlarm();
-		OCP\Util::writeLog('calendar background job', 'Finished', OCP\Util::DEBUG);
-	}
+            return false;
+        }
+        // OCP\Util::writeLog('calendar background job', 'Finished', OCP\Util::DEBUG);
+    }
 
-	private static function sendEmailAlarm() {
-		try{
-			$tz = OC_Calendar_App::getTimezone();
+    /**
+     * Fetch all callable alarms and execute them
+     * using the convenient function for a given alarm type.
+     * @return null
+     */
+    private static function dispatch()
+    {
+        $alarms = array('EMAIL' => array(), 'WEBHOOK' => array());
+        $sql = 'SELECT userid, displayname, summary, startdate, enddate, alarms.id AS alarmId, alarms.type AS alarmType, alarms.optionfield AS alarmOptionfield
+        FROM *PREFIX*clndr_objects AS objects
+        JOIN *PREFIX*clndr_calendars AS calendars ON (objects.calendarid=calendars.id)
+        JOIN *PREFIX*clndr_alarms AS alarms ON (objects.id=alarms.objid)
+        WHERE alarms.senddate <= ? AND alarms.sent = 0 AND alarms.type IN(?, ?)
+        ORDER BY userid, startdate, enddate';
+        $query = \OCP\DB::prepare($sql);
+        $results = $query->execute(array(gmdate('Y-m-d H:i:s'), 'EMAIL', 'WEBHOOK'));
+        while ($row = $results->fetchRow()) {
+            switch ($row['alarmType']) {
+                case 'EMAIL':
+                    $alarms['EMAIL'][] = $row;
+                break;
+                case 'WEBHOOK':
+                    $alarms['WEBHOOK'][] = $row;
+                break;
+            }
+        }
 
-			$sql = 'SELECT userid, displayname, summary, startdate, enddate, alarms.id as alarmId
-                    FROM *PREFIX*clndr_objects AS objects
-                    JOIN *PREFIX*clndr_calendars AS calendars ON (objects.calendarid=calendars.id)
-                    JOIN *PREFIX*clndr_alarms AS alarms ON (objects.id=alarms.objid)
-                    WHERE alarms.senddate <= UTC_TIMESTAMP() AND alarms.sent = 0 AND alarms.type = ?
-                    ORDER BY userid, startdate, enddate';
+        if (!empty($alarms['EMAIL'])) {
+            try {
+                OCP\Util::writeLog('calendar background job', 'Will send '.count($alarms['EMAIL']).' emails', OCP\Util::DEBUG);
+                static::sendEmailsAlarm($alarms['EMAIL']);
+            } catch (\Exception $e) {
+                OC_Log::write('calendar background job', 'Exception(EMAIL): '.$e->getMessage(), OCP\Util::DEBUG);
 
-			$query = \OCP\DB::prepare($sql);
-			$result = $query->execute(array('EMAIL'));
-			
-			OCP\Util::writeLog('calendar background job', 'Will send '.$result->rowCount().' emails', OCP\Util::DEBUG);
-			while($row = $result->fetchRow()){
-				$lang = OCP\Config::getUserValue($row['userid'], 'calendar', 'lang');
-				$l = OC_L10N::get('calendar', $lang);
+                return false;
+            }
+        }
+        if (!empty($alarms['WEBHOOK'])) {
+            try {
+                OCP\Util::writeLog('calendar background job', 'Will call '.count($alarms['WEBHOOK']).' webhooks', OCP\Util::DEBUG);
+                static::sendWebhooksAlarm($alarms['WEBHOOK']);
+            } catch (\Exception $e) {
+                OC_Log::write('calendar background job', 'Exception(WEBHOOK): '.$e->getMessage(), OCP\Util::DEBUG);
 
-				$startDate = new DateTime($row['startdate'], new DateTimeZone('UTC'));
-				$endDate = new DateTime($row['enddate'], new DateTimeZone('UTC'));
-				$startDate->setTimezone(new DateTimeZone($tz));
-				$endDate->setTimezone(new DateTimeZone($tz));
+                return false;
+            }
+        }
+    }
 
-				$timeFormat = OCP\Config::getUserValue($row['userid'], 'calendar', 'timeformat', '24') == 24 ? 'H:i' : 'h:i a';
-				$dateFormat = OCP\Config::getUserValue($row['userid'], 'calendar', 'dateformat', 'dd-mm-yy') == 'dd-mm-yy' ? 'd-m-Y' : 'm-d-Y';
-				$dateTimeFormat = $dateFormat.' '.$timeFormat;
+    private static function sendWebhooksAlarm($WebhookAlarms)
+    {
+        foreach ($WebhookAlarms as $alarm) {
 
-				$tpl = new \OCP\Template('calendar', 'event.alarm');
-				$tpl->assign('calendarName', $row['displayname']);
-				$tpl->assign('event', $row['summary']);
-				$tpl->assign('date', $startDate->format($dateTimeFormat).' - '.$endDate->format($dateTimeFormat));
-				$tpl->assign('when', $l->t('When: '));
-				$tpl->assign('calendar', $l->t('Calendar: '));
+            $tpl = new \OCP\Template('calendar', 'event.alarm.text');
+            $message = urlencode(static::genMessage($tpl, $alarm));
 
-				$content = $tpl->fetchPage();
+            $queryTag = null;
+            $queryValue = null;
 
-				$email = OCP\Config::getUserValue($row['userid'], 'settings', 'email');
-				$fromEmail = OC_Config::getValue('mail_smtpname');
-				if($fromEmail === NULL){
-					$fromEmail = OC_Config::getValue('mail_from_address').'@'.OC_Config::getValue('mail_domain');
-				}
-				
-				//OCP\Util::writeLog('calendar background job', 'Send mail to '.$email, OCP\Util::DEBUG);
-				$mailer = \OC::$server->getMailer();
-				$message = $mailer->createMessage();
-				$message->setSubject($l->t('Reminder: %s', $row['summary']));
-				$message->setFrom(array($fromEmail => 'Owncloud Calendar'));
-				$message->setTo(array($email => $row['userid']));
-				$message->setPlainBody($content);
-				$mailer->send($message);
-				
-				//OCP\Util::writeLog('calendar background job', 'Mail sent to '.$email, OCP\Util::DEBUG);							
-				$stmt = OCP\DB::prepare('UPDATE `*PREFIX*clndr_alarms` SET sent = 1 WHERE `id` = ?');
-				$stmt->execute(array($row['alarmId']));
-			}
-		} catch(\Exception $e){
-			OC_Log::write('calendar background job', 'Exception: '.$e->getMessage(), OCP\Util::DEBUG);		
-			return false;
-		}
-		return true;
-	}
+            $matches = array();
+            preg_match_all('/([^?=&]+)(=([^&]*))?/', $alarm['alarmOptionfield'], $matches);
 
+            // search in group 3 for $message
+            if (!empty($matches[3])) {
+                foreach ($matches[3] as $i => $qV) {
+                    if (strtolower($qV) == '$message') {
+                        $queryTag = $matches[1][$i];
+                        $queryValue = $qV;
+                        break;
+                    }
+                }
+            }
+
+            $escR = function($string) {
+                return preg_quote($string, '. \ + * ? [ ^ ] $ ( ) { } = ! < > | : -');
+            };
+
+            if (!empty($queryTag) AND !empty($queryValue)) {
+                $url = preg_replace('/([&?])'.$escR($queryTag).'='.$escR($queryValue).'/', '${1}'.$queryTag."=$message", $alarm['alarmOptionfield']);
+                // OCP\Util::writeLog('calendar background job', 'calling '.$url, OCP\Util::DEBUG);
+                $curl = new Curl($url);
+                $curl->createCurl();
+                // OCP\Util::writeLog('calendar background job', 'url called '.$curl->getHttpStatus().' '.print_r($curl->getContentType(), true).' '.print_r($curl->getInfos(), true), OCP\Util::DEBUG);
+                // OCP\Util::writeLog('calendar background job', 'Webhook called '.$alarm['alarmOptionfield'], OCP\Util::DEBUG);
+            } else {
+                // maybe the option field should not be saved in log since it can contain some credentials
+                OCP\Util::writeLog('calendar background job', 'failed to parse url '.$alarm['alarmOptionfield'], OCP\Util::DEBUG);
+            }
+
+            static::setAlarmSent($alarm['alarmId']);
+        }
+    }
+
+    /**
+     * Send all programmed Email alarms
+     * @param  Array $emailAlarms   pdo array collection of alarms
+     * @return Bool  true
+     */
+    private static function sendEmailsAlarm($emailAlarms)
+    {
+        foreach ($emailAlarms as $alarm) {
+            $lang = OCP\Config::getUserValue($alarm['userid'], 'calendar', 'lang');
+            $l = OC_L10N::get('calendar', $lang);
+
+            $tpls = array('tpl' => new \OCP\Template('calendar', 'event.alarm'), 'tpltxt' => new \OCP\Template('calendar', 'event.alarm.text'));
+            $tplclb = function ($tpl) use ($alarm) {
+               return static::genMessage($tpl, $alarm);
+            };
+            $tpls = array_map($tplclb, $tpls);
+
+            $email = OCP\Config::getUserValue($alarm['userid'], 'settings', 'email');
+            $fromEmail = OC_Config::getValue('mail_smtpname');
+            if ($fromEmail === null) {
+                $fromEmail = OC_Config::getValue('mail_from_address').'@'.OC_Config::getValue('mail_domain');
+            }
+
+            // OCP\Util::writeLog('calendar background job', 'Send mail to '.$email, OCP\Util::DEBUG);
+            $mailer = \OC::$server->getMailer();
+            $message = $mailer->createMessage();
+            $message->setSubject($l->t('Reminder: %s', $alarm['summary']));
+            $message->setFrom(array($fromEmail => 'Owncloud Calendar'));
+            $message->setTo(array($email => $alarm['userid']));
+            $message->setHtmlBody($tpls['tpl']);
+            $message->setPlainBody($tpls['tpltxt']);
+            $mailer->send($message);
+            //OCP\Util::writeLog('calendar background job', 'Mail sent to '.$email, OCP\Util::DEBUG);
+
+            // static::setAlarmSent($alarm['alarmId']);
+        }
+
+        return true;
+    }
+
+   /**
+     * Set an alarm as sent in database
+     * @param [type] $alarmId [description]
+     */
+    private static function setAlarmSent($alarmId)
+    {
+        $stmt = OCP\DB::prepare('UPDATE `*PREFIX*clndr_alarms` SET sent = 1 WHERE `id` = ?');
+        $stmt->execute(array($alarmId));
+    }
+
+    /**
+     * Generates the message to send to the user
+     * @param  \OCP\Template    &$tpl      the template
+     * @param  Array            $alarm     the pdo row to user
+     * @return string                      the rendered template
+     */
+    private static function genMessage(&$tpl, $alarm)
+    {
+        $tz = OC_Calendar_App::getTimezone();
+        $lang = OCP\Config::getUserValue($alarm['userid'], 'calendar', 'lang');
+        $l = OC_L10N::get('calendar', $lang);
+
+        $startDate = new DateTime($alarm['startdate'], new DateTimeZone('UTC'));
+        $endDate = new DateTime($alarm['enddate'], new DateTimeZone('UTC'));
+        $startDate->setTimezone(new DateTimeZone($tz));
+        $endDate->setTimezone(new DateTimeZone($tz));
+        $timeFormat = OCP\Config::getUserValue($alarm['userid'], 'calendar', 'timeformat', '24') == 24 ? 'H:i' : 'h:i a';
+        $dateFormat = OCP\Config::getUserValue($alarm['userid'], 'calendar', 'dateformat', 'dd-mm-yy') == 'dd-mm-yy' ? 'd-m-Y' : 'm-d-Y';
+        $dateTimeFormat = $dateFormat.' '.$timeFormat;
+
+        $tpl->assign('calendarName', $alarm['displayname']);
+        $tpl->assign('event', $alarm['summary']);
+        $tpl->assign('date', $startDate->format($dateTimeFormat).' - '.$endDate->format($dateTimeFormat));
+        $tpl->assign('when', $l->t('When: '));
+        $tpl->assign('calendar', $l->t('Calendar: '));
+        return $tpl->fetchPage();
+    }
 }

--- a/templates/calendar.php
+++ b/templates/calendar.php
@@ -108,6 +108,20 @@
 					<label class="bold"><?php p($l->t('iOS/OS X CalDAV address')); ?></label>
 					<input id="ioscaldav" type="text" value="<?php print_unescaped(OCP\Util::linkToRemote('caldav')); ?>principals/<?php p(urlencode(OCP\USER::getUser())); ?>/" style="width:90%" readonly>
 				</li>
+				<li>
+					<?php $_alarmsType = explode('|', OCP\Config::getUserValue( OCP\USER::getUser(), 'calendar', 'defaultalarms' )) ?>
+					<span class="bold alarmDefault"><?php p($l->t('Default Alarms')); ?></span>
+					<input id="alarmDefaultPopup" class="alarmDefault" type="checkbox" name="DISPLAY" value="" <?php echo in_array('DISPLAY', $_alarmsType)?'checked="checked"':''?>>
+					<label for="alarmDefaultPopup"><?php p($l->t('Popup')); ?></label>
+					<input id="alarmDefaultMail" class="alarmDefault" type="checkbox" name="EMAIL" value="" <?php echo in_array('EMAIL', $_alarmsType)?'checked="checked"':''?>>
+					<label for="alarmDefaultMail"><?php p($l->t('Mail')); ?></label>
+					<input id="alarmDefaultWebhook" class="alarmDefault" type="checkbox" name="WEBHOOK" value="" <?php echo in_array('WEBHOOK', $_alarmsType)?'checked="checked"':''?>>
+					<label for="alarmDefaultWebhook"><?php p($l->t('Webhook')); ?></label>
+				</li>
+				<li>
+					<label for="alarmDefaultWebhookURL" class="bold"><?php p($l->t('Webhook default URL')); ?></label>
+					<input id="alarmDefaultWebhookURL" type="text" value="<?php echo OCP\Config::getUserValue( OCP\USER::getUser(), 'calendar', 'webhookdefaulturl' ) ?>" style="width:90%">
+				</li>
 			</ul>
 		</div>
 	</div>

--- a/templates/event.alarm.text.php
+++ b/templates/event.alarm.text.php
@@ -1,0 +1,10 @@
+    <?php p($_['event']); ?>
+
+        <?php p($_['when']); ?>
+        <?php p($_['date']); ?>
+
+        <?php p($_['calendar']); ?>
+        <?php p($_['calendarName']); ?>
+
+
+

--- a/templates/part.eventform.php
+++ b/templates/part.eventform.php
@@ -57,86 +57,84 @@
     <div id="eventAlarms">
 		<?php
 		p($l->t("Reminders"));
+		$i = 0;
+		foreach($_['alarms'] as $row): ?>
 
-		if(count($_['alarms']) == 0){
-			?>
-
-			<div class="alarm" style="display:none">
-				<select style="width:80px;" class="alarmType" name="">
-					<option value="EMAIL"><?php p($l->t('Email')); ?></option>
-					<option value="DISPLAY"><?php p($l->t('Popup')); ?></option>
+			<div class="alarm">
+				<select style="width:95px;" class="alarmType" name="alarmsType[<?php p($i); ?>]">
+					<?php
+					print_unescaped('<option value="EMAIL" '.($row['type']=='EMAIL'?'selected="selected"':'').'>'.$l->t('Email').'</option>');
+					print_unescaped('<option value="DISPLAY" '.($row['type']=='DISPLAY'?'selected="selected"':'').'>'.$l->t('Popup').'</option>');
+					print_unescaped('<option value="WEBHOOK" '.($row['type']=='WEBHOOK'?'selected="selected"':'').'>'.$l->t('Webhook').'</option>');
+					?>
 				</select>
-				<input style="width:25px;" type="text" value="10" class="alarmDuration" name=""/>
-				<select style="width:145px;" class="alarmTimeType" name="">
-					<option value="M"><?php p($l->t('Minutes')); ?></option>
-					<option value="H"><?php p($l->t('Hours')); ?></option>
-					<option value="D"><?php p($l->t('Days')); ?></option>
-					<option value="W"><?php p($l->t('Weeks')); ?></option>
+				<input style="width:25px;" type="text" value="<?php p($row['value']) ?>" class="alarmDuration" name="alarmsDuration[<?php p($i); ?>]"/>
+				<select style="width:145px;" class="alarmTimeType" name="alarmsTimeType[<?php p($i); ?>]">
+					<?php switch($row['timetype']) {
+						case 'M':
+
+							print_unescaped('<option value="M" selected="selected">'.$l->t('Minutes').'</option>');
+							print_unescaped('<option value="H">'.$l->t('Hours').'</option>');
+							print_unescaped('<option value="D">'.$l->t('Days').'</option>');
+							print_unescaped('<option value="W">'.$l->t('Weeks').'</option>');
+							break;
+						case 'H':
+
+							print_unescaped('<option value="M">'.$l->t('Minutes').'</option>');
+							print_unescaped('<option value="H" selected="selected">'.$l->t('Hours').'</option>');
+							print_unescaped('<option value="D">'.$l->t('Days').'</option>');
+							print_unescaped('<option value="W">'.$l->t('Weeks').'</option>');
+							break;
+						case 'D':
+
+							print_unescaped('<option value="M">'.$l->t('Minutes').'</option>');
+							print_unescaped('<option value="H">'.$l->t('Hours').'</option>');
+							print_unescaped('<option value="D" selected="selected">'.$l->t('Days').'</option>');
+							print_unescaped('<option value="W">'.$l->t('Weeks').'</option>');
+							break;
+						default: // W
+							print_unescaped('<option value="M">'.$l->t('Minutes').'</option>');
+							print_unescaped('<option value="H">'.$l->t('Hours').'</option>');
+							print_unescaped('<option value="D">'.$l->t('Days').'</option>');
+							print_unescaped('<option value="W" selected="selected">'.$l->t('Weeks').'</option>');
+							break;
+                    }?>
 				</select>
 				<button class="deleteAlarm"><?php p($l->t("Delete")); ?></button>
+				<label class="alarmOptionField" <?php print_unescaped($row['type']!='WEBHOOK'?'style="display: none;"':'') ?>>
+					<span style="width: 35%;">Url eg: uri&amp;m=<b>$message</b>:</span>
+					<?php $_dv = OCP\Config::getUserValue( OCP\USER::getUser(), 'calendar', 'webhookdefaulturl' ); ?>
+					<?php if (!empty($row['optionfield'])): ?>
+						<input style="width: 60%;" type="text" value="<?php p($row['optionfield']) ?>" class="alarmOptionField" name="alarmsOptionField[<?php p($i); ?>]"/>
+					<?php else: ?>
+						<input style="width: 60%;" type="text" value="<?php echo $_dv ?>" class="alarmOptionField" name="alarmsOptionField[<?php p($i); ?>]"/>
+					<?php endif; ?>
+				</label>
 			</div>
 
-			<?php
-		}else{
+			<?php $i++;
+		endforeach; ?>
 
-			$i = 0;
-			foreach($_['alarms'] as $row){
-				?>
-
-				<div class="alarm">
-					<select style="width:80px;" class="alarmType" name="alarmsType[<?php p($i); ?>]">
-						<?php
-						if($row['type'] == 'EMAIL'){
-							print_unescaped('<option value="EMAIL" selected="selected">'.$l->t('Email').'</option>');
-							print_unescaped('<option value="DISPLAY">'.$l->t('Popup').'</option>');
-						}else{
-							print_unescaped('<option value="EMAIL">'.$l->t('Email').'</option>');
-							print_unescaped('<option value="DISPLAY" selected="selected">'.$l->t('Popup').'</option>');
-						}
-						?>
-					</select>
-					<input style="width:25px;" type="text" value="<?php p($row['value']) ?>" class="alarmDuration" name="alarmsDuration[<?php p($i); ?>]"/>
-					<select style="width:145px;" class="alarmTimeType" name="alarmsTimeType[<?php p($i); ?>]">
-                                <?php
-						switch($row['timetype']){
-							case 'M':
-
-								print_unescaped('<option value="M" selected="selected">'.$l->t('Minutes').'</option>');
-								print_unescaped('<option value="H">'.$l->t('Hours').'</option>');
-								print_unescaped('<option value="D">'.$l->t('Days').'</option>');
-								print_unescaped('<option value="W">'.$l->t('Weeks').'</option>');
-								break;
-							case 'H':
-
-								print_unescaped('<option value="M">'.$l->t('Minutes').'</option>');
-								print_unescaped('<option value="H" selected="selected">'.$l->t('Hours').'</option>');
-								print_unescaped('<option value="D">'.$l->t('Days').'</option>');
-								print_unescaped('<option value="W">'.$l->t('Weeks').'</option>');
-								break;
-							case 'D':
-                                        
-								print_unescaped('<option value="M">'.$l->t('Minutes').'</option>');
-								print_unescaped('<option value="H">'.$l->t('Hours').'</option>');
-								print_unescaped('<option value="D" selected="selected">'.$l->t('Days').'</option>');
-								print_unescaped('<option value="W">'.$l->t('Weeks').'</option>');
-								break;
-							default: // W
-								print_unescaped('<option value="M">'.$l->t('Minutes').'</option>');
-								print_unescaped('<option value="H">'.$l->t('Hours').'</option>');
-								print_unescaped('<option value="D">'.$l->t('Days').'</option>');
-								print_unescaped('<option value="W" selected="selected">'.$l->t('Weeks').'</option>');
-								break;
-                                    }
-                                ?>
+		<div id="baseEventAlarm" class="alarm" style="display:none">
+			<select style="width:95px;" class="alarmType" name="">
+				<option value="EMAIL"><?php p($l->t('Email')); ?></option>
+				<option value="DISPLAY"><?php p($l->t('Popup')); ?></option>
+				<option value="WEBHOOK"><?php p($l->t('Webhook')); ?></option>
 			</select>
-					<button class="deleteAlarm"><?php p($l->t("Delete")); ?></button>
-				</div>
-
-			<?php
-				$i++;
-			}
-				}
-			?>
+			<input style="width:25px;" type="text" value="10" class="alarmDuration" name=""/>
+			<select style="width:145px;" class="alarmTimeType" name="">
+				<option value="M"><?php p($l->t('Minutes')); ?></option>
+				<option value="H"><?php p($l->t('Hours')); ?></option>
+				<option value="D"><?php p($l->t('Days')); ?></option>
+				<option value="W"><?php p($l->t('Weeks')); ?></option>
+			</select>
+			<button class="deleteAlarm"><?php p($l->t("Delete")); ?></button>
+			<label class="alarmOptionField" style="display: none;">
+				<span style="width: 35%;">Url eg: uri&amp;m=<b>$message</b>:</span>
+				<input style="width: 60%;" class="alarmOptionField" type="text" name="" value="<?php echo OCP\Config::getUserValue( OCP\USER::getUser(), 'calendar', 'webhookdefaulturl' ) ?>" />
+			</label>
+		</div>
+		<script>var __b = $('#baseEventAlarm'); Calendar.UI.ALARMBASETPL = __b.attr('id','').prop('outerHTML'); __b.remove();</script>
 
 		<button id="add_alarm"><?php p($l->t("Add reminder")); ?></button>
 


### PR DESCRIPTION
This is fixing some bug encountered, It also introduce Webhook alarm type

It adds : 
- Webhook option in reminders
- url field in reminders
- default configuration for reminders in calendar option pannel
- bind CALDAV AUDIO to the webhook alarm to provide a way to set a webhook alarm from a client

**README.md**               add optionfield
**appinfo/database.xml**    add optionfield with length at 1024 since max url is 2000 should be ok
**ajax/event/new.php**      add $_POST['alarmsOptionField'] to OC_Calendar_Object::addAlarmsDB call
**ajax/event/edit.php**     add $_POST['alarmsOptionField'] to OC_Calendar_Object::addAlarmsDB call
**ajax/event/new.form.php** add default for all Alarm Types in initialize default optionfield
**js/on-event.js**          add .alarmType (select) change event
**js/settings.js**          add saving methods for default alarm types and default webhook url
**js/calendar.js**

```
    add switchAlarmType to show hide optionfield input depending on alarm type
    removes the hidden default alarm since it is send and saved on the DB
        instead base alarm html is written in Calendar.UI.ALARMBASETPL by the template
        and used in addAlarm
```

**templates/calendar.php**  add alarm configuration html
**templates/part.eventform.php**

```
    add default alarm template (sotes it in Calendar.UI.ALARMBASETPL)
    add Webhook Option
    initialize default optionfield
```

**lib/alarm.php**

```
    made PS2 compliant with phpcs since it make a lot of changes
    add function dispatch to call apropriate function for a given alarm type
        also replaces some sql functions with native php since sqlite does these
    add sendWebhooksAlarm exec WEBHOOK alarms with the new curl class and therefore replaces
        $message in option field with urlencoded text template (same as email plain text)
        this function uses regex to achieve replacement and url parsing
    add sendEmailsAlarm exec EMAIL alarms and send them in html and plain text (added html boundarie)
    add setAlarmSent makes the alarm as sent in database (refactored)
    add genMessage to generate a template (html, text) (refactored)
```

**lib/object.php**

```
    add optionfield in SELECT and INSERT to needed sql queries
    replace some SQL function (DATE_SUB, UTC_TIMESTAMP, INTERVAL) with native php since sqlite does not
        support these
    bind AUDIO to WEBHOOK and vice versa to provide a method to set webhook using CALDAV
        see http://www.ietf.org/rfc/rfc4791.txt 8.6.  Storing and Using Alarms
```

add **ajax/settings/setdefaultalarms.php**
add **ajax/settings/setwebhookdefaulturl.php**
add **templates/event.alarm.text.php**
**appinfo/routes.php**      add routes setdefaultalarms and setwebhookdefaulturls
**css/style.css**           add .webhookUrlEvent and .alarmOptionField style rules
